### PR TITLE
WIP: Hyperlink DOIs to preferred resolver

### DIFF
--- a/war/jsp/orderview.jsp
+++ b/war/jsp/orderview.jsp
@@ -208,7 +208,7 @@
          <tr>
         <th id="th-left">DOI</th>
       </tr>
-      <tr><td id="border"><a href="http://dx.doi.org/<% out.println(crossref.replaceAll("info:doi/", "").replaceAll("http://dx.doi.org/", "").replaceAll("doi:", "").trim()); %>" target="_blank">http://dx.doi.org/<% out.println(crossref.replaceAll("info:doi/", "").replaceAll("http://dx.doi.org/", "").replaceAll("doi:", "").trim()); %></a>&nbsp;</td></tr>
+      <tr><td id="border"><a href="https://doi.org/<% out.println(crossref.replaceAll("info:doi/", "").replaceAll("http://dx.doi.org/", "").replaceAll("doi:", "").trim()); %>" target="_blank">https://doi.org/<% out.println(crossref.replaceAll("info:doi/", "").replaceAll("http://dx.doi.org/", "").replaceAll("doi:", "").trim()); %></a>&nbsp;</td></tr>
     </table>
   </logic:notEmpty>
   </td>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Also, I noticed the old base URL in the code duplicates

https://github.com/gbv/doctor-doc/blob/7446ab7bc1568f56ac28571d058e438b5a02c366/source/ch/dbs/actions/bestellung/BestellformAction.java#L735-L746

and 

https://github.com/gbv/doctor-doc/blob/7446ab7bc1568f56ac28571d058e438b5a02c366/source/ch/dbs/actions/bestellung/BestellformAction.java#L807-L818

- [ ] also update both, deduplicate or refactor?

Cheers!